### PR TITLE
Fix high load for network_status

### DIFF
--- a/network_status.py
+++ b/network_status.py
@@ -1,26 +1,32 @@
-import os
+# Original: https://github.com/JeremyRuhland/klipper_network_status
+import os, logging
 
 class network_status:
     def __init__(self, config):
+        self.interval = config.getint('interval', 60, minval=10)
         self.ethip = "N/A"
         self.wifiip = "N/A"
         self.wifissid = "N/A"
         self.mdns = "N/A"
+        self.last_eventtime = 0
 
     def get_status(self, eventtime):
-        try:
-            self.ethip = os.popen('ip addr show eth0').read().split("inet ")[1].split("/")[0]
-        except:
-            self.ethip = "N/A"
+        if eventtime - self.last_eventtime > self.interval:
+            self.last_eventtime = eventtime
+            logging.info("network_status get_status %d" % eventtime)
+            try:
+                self.ethip = os.popen('ip addr show eth0').read().split("inet ")[1].split("/")[0]
+            except:
+                self.ethip = "N/A"
 
-        try:
-            self.wifiip = os.popen('ip addr show wlan0').read().split("inet ")[1].split("/")[0]
-            self.wifissid = os.popen('iwgetid -r').read()[:-1]
-        except:
-            self.wifiip = "N/A"
-            self.wifissid = "N/A"
+            try:
+                self.wifiip = os.popen('ip addr show wlan0').read().split("inet ")[1].split("/")[0]
+                self.wifissid = os.popen('iwgetid -r').read()[:-1]
+            except:
+                self.wifiip = "N/A"
+                self.wifissid = "N/A"
 
-        self.mdns = os.popen('hostname').read()[:-1] + '.local'
+            self.mdns = os.popen('hostname').read()[:-1] + '.local'
 
         return {'ethip': self.ethip,
             'wifiip': self.wifiip,


### PR DESCRIPTION
get_status is typically executed four times per second. Multiple process launches here are quite hard work for the Raspberry Pi.

This PR introduce `interval` parameter which has default value of 60. 