### PR TITLE
Add ".git" into update manager URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ also add the following to your moonraker configuration:
 [update_manager client klipper_network_status]
 type: git_repo
 path: /home/pi/klipper_network_status
-origin: https://github.com/JeremyRuhland/klipper_network_status
+origin: https://github.com/JeremyRuhland/klipper_network_status.git
 install_script: install.sh
 ```
 


### PR DESCRIPTION
Hi!

I was getting this error message in the Moonraker logs
```
2023-03-26 15:38:13,048 [base_deploy.py:log_info()] - Application klipper_network_status: Channel: dev, Need Channel Update: False
2023-03-26 15:38:13,048 [base_deploy.py:log_info()] - Application klipper_network_status: Repo validation checks failed:
Unofficial remote url: https://github.com/JeremyRuhland/klipper_network_status.git
2023-03-26 15:38:13,048 [base_deploy.py:log_info()] - Application klipper_network_status: Updates on repo disabled
2023-03-26 15:38:13,050 [common.py:build_error()] - JSON-RPC Request Error: 500
Recovery attempt failed, repo state not pristine

```

[This](https://github.com/Arksine/moonraker/blob/110cbd108409aecb4e5654b0f811cad047cd909b/moonraker/components/update_manager/git_deploy.py#L707) function in Moonraker is what's performing the check - if the repo name doesn't match exactly, it flags the repo as invalid.


Fix: Add ".git" suffix into update URL to pass Moonraker git repo validity check