### PR TITLE
Adding interface names to klipper config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ readability to put the actual hostname or IP address on its own line. It should
 scroll side to side when the selection cursor hovers over it.
 
 Optionally you can add an `interval` parameter to your klipper config under the `[network_status]` section to select how often the network information is updated. Default is once per minute if you do not specify.
-If you ethernet or wifi interface names are different from eth0 and wlan0, you can add an `intethname` and `intwifiname` parameter to your klipper config under the `[network_status]` section to specify your interface names.
+
+If your ethernet or wifi interface names are different from eth0 and wlan0, you can add an `intethname` and `intwifiname` parameter to your klipper config under the `[network_status]` section to specify your interface names.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ readability to put the actual hostname or IP address on its own line. It should
 scroll side to side when the selection cursor hovers over it.
 
 Optionally you can add an `interval` parameter to your klipper config under the `[network_status]` section to select how often the network information is updated. Default is once per minute if you do not specify.
+If you ethernet or wifi interface names are different from eth0 and wlan0, you can add an `intethname` and `intwifiname` parameter to your klipper config under the `[network_status]` section to specify your interface names.

--- a/network_status.py
+++ b/network_status.py
@@ -4,6 +4,8 @@ import os, logging
 class network_status:
     def __init__(self, config):
         self.interval = config.getint('interval', 60, minval=10)
+        self.intethname = config.get('intethname', 'eth0')
+        self.intwifiname = config.get('intwifiname','wlan0')
         self.ethip = "N/A"
         self.wifiip = "N/A"
         self.wifissid = "N/A"
@@ -15,12 +17,12 @@ class network_status:
             self.last_eventtime = eventtime
             logging.info("network_status get_status %d" % eventtime)
             try:
-                self.ethip = os.popen('ip addr show eth0').read().split("inet ")[1].split("/")[0]
+                self.ethip = os.popen("ip addr show %s" % self.intethname).read().split("inet ")[1].split("/")[0]
             except:
                 self.ethip = "N/A"
 
             try:
-                self.wifiip = os.popen('ip addr show wlan0').read().split("inet ")[1].split("/")[0]
+                self.wifiip = os.popen("ip addr show %s" % self.intwifiname).read().split("inet ")[1].split("/")[0]
                 self.wifissid = os.popen('iwgetid -r').read()[:-1]
             except:
                 self.wifiip = "N/A"


### PR DESCRIPTION
Allow to configure eth0 and wlan0 names as in linux they can be presented as ifnames